### PR TITLE
Improved support for External Annotations

### DIFF
--- a/src/CodeContractNullability/CodeContractNullability.Test/CodeContractNullability.Test.csproj
+++ b/src/CodeContractNullability/CodeContractNullability.Test/CodeContractNullability.Test.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ExactSourceCode.cs" />
     <Compile Include="GitHubIssueAttribute.cs" />
     <Compile Include="ItemNullabilityNUnitRoslynTest.cs" />
+    <Compile Include="NullabilityAnalysisTestFixture.cs" />
     <Compile Include="NullabilityNUnitRoslynTest.cs" />
     <Compile Include="ParsedSourceCode.cs" />
     <Compile Include="RoslynTestFramework\AnalysisTestFixture.cs" />

--- a/src/CodeContractNullability/CodeContractNullability.Test/ItemNullabilityNUnitRoslynTest.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/ItemNullabilityNUnitRoslynTest.cs
@@ -1,57 +1,17 @@
-using CodeContractNullability.ExternalAnnotations.Storage;
-using CodeContractNullability.NullabilityAttributes;
-using CodeContractNullability.Test.RoslynTestFramework;
-using CodeContractNullability.Test.TestDataBuilders;
-using CodeContractNullability.Utilities;
-using JetBrains.Annotations;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace CodeContractNullability.Test
 {
-    internal abstract class ItemNullabilityNUnitRoslynTest : AnalysisTestFixture
+    internal abstract class ItemNullabilityNUnitRoslynTest : NullabilityAnalysisTestFixture
     {
-        [NotNull]
-        private ExternalAnnotationsMap externalAnnotationsMap = new ExternalAnnotationsBuilder().Build();
-
         protected override string DiagnosticId => CodeContractItemNullabilityAnalyzer.DiagnosticId;
 
-        protected void VerifyItemNullabilityDiagnostic([NotNull] ParsedSourceCode source)
+        protected override string NotNullAttributeName => "ItemNotNull";
+        protected override string CanBeNullAttributeName => "ItemCanBeNull";
+
+        protected override BaseAnalyzer CreateNullabilityAnalyzer()
         {
-            Guard.NotNull(source, nameof(source));
-
-            externalAnnotationsMap = source.ExternalAnnotationsMap;
-
-            AnalyzerTestContext analyzerTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
-                .WithReferences(source.References)
-                .WithFileName(source.Filename);
-
-            AssertDiagnostics(analyzerTextContext);
-        }
-
-        protected void VerifyItemNullabilityFix([NotNull] ParsedSourceCode source)
-        {
-            Guard.NotNull(source, nameof(source));
-
-            string fixNotNull = source.GetExpectedTextForAttribute("ItemNotNull");
-            string fixCanBeNull = source.GetExpectedTextForAttribute("ItemCanBeNull");
-
-            AnalyzerTestContext analyzeTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
-                .WithReferences(source.References)
-                .WithFileName(source.Filename);
-            var fixTestContext = new FixProviderTestContext(analyzeTextContext, new[] { fixNotNull, fixCanBeNull },
-                source.ReIndentExpected);
-
-            AssertDiagnosticsWithCodeFixes(fixTestContext);
-        }
-
-        protected override DiagnosticAnalyzer CreateAnalyzer()
-        {
-            var analyzer = new CodeContractItemNullabilityAnalyzer();
-            analyzer.ExternalAnnotationsRegistry.Override(externalAnnotationsMap);
-            analyzer.NullabilityAttributeProvider.Override(new SimpleNullabilityAttributeProvider());
-            return analyzer;
+            return new CodeContractItemNullabilityAnalyzer();
         }
 
         protected override CodeFixProvider CreateFixProvider()

--- a/src/CodeContractNullability/CodeContractNullability.Test/NullabilityAnalysisTestFixture.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/NullabilityAnalysisTestFixture.cs
@@ -1,0 +1,64 @@
+using CodeContractNullability.ExternalAnnotations;
+using CodeContractNullability.NullabilityAttributes;
+using CodeContractNullability.Test.RoslynTestFramework;
+using CodeContractNullability.Test.TestDataBuilders;
+using CodeContractNullability.Utilities;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodeContractNullability.Test
+{
+    internal abstract class NullabilityAnalysisTestFixture : AnalysisTestFixture
+    {
+        [NotNull]
+        private IExternalAnnotationsResolver externalAnnotationsResolver =
+            new SimpleExternalAnnotationsResolver(new ExternalAnnotationsBuilder().Build());
+
+        [NotNull]
+        protected abstract string NotNullAttributeName { get; }
+
+        [NotNull]
+        protected abstract string CanBeNullAttributeName { get; }
+
+        protected void VerifyNullabilityDiagnostic([NotNull] ParsedSourceCode source)
+        {
+            Guard.NotNull(source, nameof(source));
+
+            externalAnnotationsResolver = new SimpleExternalAnnotationsResolver(source.ExternalAnnotationsMap);
+
+            AnalyzerTestContext analyzerTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
+                .WithReferences(source.References)
+                .WithFileName(source.Filename);
+
+            AssertDiagnostics(analyzerTextContext);
+        }
+
+        protected void VerifyNullabilityFix([NotNull] ParsedSourceCode source)
+        {
+            Guard.NotNull(source, nameof(source));
+
+            string fixNotNull = source.GetExpectedTextForAttribute(NotNullAttributeName);
+            string fixCanBeNull = source.GetExpectedTextForAttribute(CanBeNullAttributeName);
+
+            AnalyzerTestContext analyzeTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
+                .WithReferences(source.References)
+                .WithFileName(source.Filename);
+            var fixTestContext = new FixProviderTestContext(analyzeTextContext, new[] { fixNotNull, fixCanBeNull },
+                source.ReIndentExpected);
+
+            AssertDiagnosticsWithCodeFixes(fixTestContext);
+        }
+
+        protected override DiagnosticAnalyzer CreateAnalyzer()
+        {
+            BaseAnalyzer analyzer = CreateNullabilityAnalyzer();
+            analyzer.ExternalAnnotationsResolver.Override(externalAnnotationsResolver);
+            analyzer.NullabilityAttributeProvider.Override(new SimpleNullabilityAttributeProvider());
+            return analyzer;
+        }
+
+        [NotNull]
+        protected abstract BaseAnalyzer CreateNullabilityAnalyzer();
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability.Test/NullabilityNUnitRoslynTest.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/NullabilityNUnitRoslynTest.cs
@@ -1,60 +1,22 @@
 using System;
 using System.IO;
 using System.Text;
-using CodeContractNullability.ExternalAnnotations.Storage;
-using CodeContractNullability.NullabilityAttributes;
-using CodeContractNullability.Test.RoslynTestFramework;
-using CodeContractNullability.Test.TestDataBuilders;
 using CodeContractNullability.Utilities;
 using JetBrains.Annotations;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace CodeContractNullability.Test
 {
-    internal abstract class NullabilityNUnitRoslynTest : AnalysisTestFixture
+    internal abstract class NullabilityNUnitRoslynTest : NullabilityAnalysisTestFixture
     {
-        [NotNull]
-        private ExternalAnnotationsMap externalAnnotationsMap = new ExternalAnnotationsBuilder().Build();
-
         protected override string DiagnosticId => CodeContractNullabilityAnalyzer.DiagnosticId;
 
-        protected void VerifyNullabilityDiagnostic([NotNull] ParsedSourceCode source)
+        protected override string NotNullAttributeName => "NotNull";
+        protected override string CanBeNullAttributeName => "CanBeNull";
+
+        protected override BaseAnalyzer CreateNullabilityAnalyzer()
         {
-            Guard.NotNull(source, nameof(source));
-
-            externalAnnotationsMap = source.ExternalAnnotationsMap;
-
-            AnalyzerTestContext analyzerTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
-                .WithReferences(source.References)
-                .WithFileName(source.Filename);
-
-            AssertDiagnostics(analyzerTextContext);
-        }
-
-        protected void VerifyNullabilityFix([NotNull] ParsedSourceCode source)
-        {
-            Guard.NotNull(source, nameof(source));
-
-            string fixNotNull = source.GetExpectedTextForAttribute("NotNull");
-            string fixCanBeNull = source.GetExpectedTextForAttribute("CanBeNull");
-
-            AnalyzerTestContext analyzeTextContext = new AnalyzerTestContext(source.GetText(), LanguageNames.CSharp)
-                .WithReferences(source.References)
-                .WithFileName(source.Filename);
-            var fixTestContext = new FixProviderTestContext(analyzeTextContext, new[] { fixNotNull, fixCanBeNull },
-                source.ReIndentExpected);
-
-            AssertDiagnosticsWithCodeFixes(fixTestContext);
-        }
-
-        protected override DiagnosticAnalyzer CreateAnalyzer()
-        {
-            var analyzer = new CodeContractNullabilityAnalyzer();
-            analyzer.ExternalAnnotationsRegistry.Override(externalAnnotationsMap);
-            analyzer.NullabilityAttributeProvider.Override(new SimpleNullabilityAttributeProvider());
-            return analyzer;
+            return new CodeContractNullabilityAnalyzer();
         }
 
         protected override CodeFixProvider CreateFixProvider()

--- a/src/CodeContractNullability/CodeContractNullability.Test/Specs/FieldCollectionSpecs.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/Specs/FieldCollectionSpecs.cs
@@ -33,7 +33,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -203,7 +203,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -224,7 +224,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -250,7 +250,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -309,7 +309,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
     }
 }

--- a/src/CodeContractNullability/CodeContractNullability.Test/Specs/MethodReturnValueCollectionSpecs.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/Specs/MethodReturnValueCollectionSpecs.cs
@@ -31,7 +31,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -226,7 +226,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -283,7 +283,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -308,7 +308,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -333,7 +333,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -362,7 +362,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -391,7 +391,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -417,7 +417,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -431,7 +431,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -446,7 +446,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -461,7 +461,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -493,7 +493,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -520,7 +520,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
     }
 }

--- a/src/CodeContractNullability/CodeContractNullability.Test/Specs/ParameterCollectionSpecs.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/Specs/ParameterCollectionSpecs.cs
@@ -29,7 +29,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -238,7 +238,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -254,7 +254,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -280,7 +280,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -310,7 +310,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -333,7 +333,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -360,7 +360,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -386,7 +386,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -415,7 +415,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -447,7 +447,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -473,7 +473,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -487,7 +487,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -502,7 +502,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -517,7 +517,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -548,7 +548,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -574,7 +574,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
     }
 }

--- a/src/CodeContractNullability/CodeContractNullability.Test/Specs/PropertyCollectionSpecs.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/Specs/PropertyCollectionSpecs.cs
@@ -31,7 +31,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -267,7 +267,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -292,7 +292,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -320,7 +320,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -359,7 +359,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -395,7 +395,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -409,7 +409,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -424,7 +424,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -439,7 +439,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
 
         [Test]
@@ -471,7 +471,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityDiagnostic(source);
+            VerifyNullabilityDiagnostic(source);
         }
 
         [Test]
@@ -498,7 +498,7 @@ namespace CodeContractNullability.Test.Specs
                 .Build();
 
             // Act and assert
-            VerifyItemNullabilityFix(source);
+            VerifyNullabilityFix(source);
         }
     }
 }

--- a/src/CodeContractNullability/CodeContractNullability.Test/TestDataBuilders/RawSourceCodeBuilder.cs
+++ b/src/CodeContractNullability/CodeContractNullability.Test/TestDataBuilders/RawSourceCodeBuilder.cs
@@ -28,7 +28,8 @@ namespace CodeContractNullability.Test.TestDataBuilders
             return this;
         }
 
-        private static string NormalizeLineBreaks(string text)
+        [NotNull]
+        private static string NormalizeLineBreaks([NotNull] string text)
         {
             return text.Replace("\n", "\r\n").Replace("\r\r", "\r");
         }

--- a/src/CodeContractNullability/CodeContractNullability/CodeContractNullability.csproj
+++ b/src/CodeContractNullability/CodeContractNullability/CodeContractNullability.csproj
@@ -37,6 +37,10 @@
     <Compile Include="CodeContractItemNullabilityCodeFixProvider.cs" />
     <Compile Include="CodeContractNullabilityCodeFixProvider.cs" />
     <Compile Include="CodeContractItemNullabilityAnalyzer.cs" />
+    <Compile Include="ExternalAnnotations\AssemblyExternalAnnotationsLoader.cs" />
+    <Compile Include="ExternalAnnotations\CachingExternalAnnotationsResolver.cs" />
+    <Compile Include="ExternalAnnotations\IExternalAnnotationsResolver.cs" />
+    <Compile Include="ExternalAnnotations\SimpleExternalAnnotationsResolver.cs" />
     <Compile Include="SymbolAnalysis\FieldAnalyzer.cs" />
     <Compile Include="SymbolAnalysis\BaseSymbolAnalyzer.cs" />
     <Compile Include="SymbolAnalysis\MethodReturnValueAnalyzer.cs" />
@@ -63,7 +67,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NullabilityAttributes\SimpleNullabilityAttributeProvider.cs" />
     <Compile Include="SymbolAnalysis\SymbolExtensions.cs" />
-    <Compile Include="ExternalAnnotations\DiskExternalAnnotationsLoader.cs" />
+    <Compile Include="ExternalAnnotations\FolderExternalAnnotationsLoader.cs" />
     <Compile Include="Utilities\StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/AssemblyExternalAnnotationsLoader.cs
+++ b/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/AssemblyExternalAnnotationsLoader.cs
@@ -1,0 +1,56 @@
+using System.IO;
+using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.Utilities;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+
+namespace CodeContractNullability.ExternalAnnotations
+{
+    /// <summary>
+    /// Attempts to find and parse a side-by-side [AssemblyName].ExternalAnnotations.xml file that resides in the same folder
+    /// as the assembly that contains the requested symbol.
+    /// </summary>
+    public static class AssemblyExternalAnnotationsLoader
+    {
+        [CanBeNull]
+        public static string GetPathForExternalSymbolOrNull([NotNull] ISymbol symbol, [NotNull] Compilation compilation)
+        {
+            Guard.NotNull(symbol, nameof(symbol));
+            Guard.NotNull(compilation, nameof(compilation));
+
+            if (symbol.ContainingAssembly != null)
+            {
+                var assemblyReference =
+                    compilation.GetMetadataReference(symbol.ContainingAssembly) as PortableExecutableReference;
+
+                string assemblyPath = assemblyReference?.FilePath;
+                string folder = Path.GetDirectoryName(assemblyPath);
+                if (folder != null)
+                {
+                    string assemblyFileName = Path.GetFileNameWithoutExtension(assemblyPath);
+                    string annotationFilePath = Path.Combine(folder, assemblyFileName + ".ExternalAnnotations.xml");
+
+                    return File.Exists(annotationFilePath) ? annotationFilePath : null;
+                }
+            }
+
+            return null;
+        }
+
+        [NotNull]
+        public static ExternalAnnotationsMap ParseFile([NotNull] string externalAnnotationsPath)
+        {
+            Guard.NotNull(externalAnnotationsPath, nameof(externalAnnotationsPath));
+
+            using (TextReader reader = File.OpenText(externalAnnotationsPath))
+            {
+                var map = new ExternalAnnotationsMap();
+
+                var parser = new ExternalAnnotationDocumentParser();
+                parser.ProcessDocument(reader, map);
+
+                return map;
+            }
+        }
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/CachingExternalAnnotationsResolver.cs
+++ b/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/CachingExternalAnnotationsResolver.cs
@@ -1,0 +1,120 @@
+using System.Collections.Concurrent;
+using System.IO;
+using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.Utilities;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+
+namespace CodeContractNullability.ExternalAnnotations
+{
+    /// <summary>
+    /// Performs one-time load of files from built-in Resharper External Annotation folders, along with a cached set of
+    /// per-assembly External Annotations (loaded from [AssemblyName].ExternalAnnotations.xml in assembly folder). The
+    /// annotation files from this last set typically come from NuGet packages or assembly references. From that set, each
+    /// per-assembly file is monitored for filesystem changes and flushed accordingly.
+    /// </summary>
+    public class CachingExternalAnnotationsResolver : IExternalAnnotationsResolver
+    {
+        [CanBeNull]
+        private ExternalAnnotationsMap globalCache;
+
+        [NotNull]
+        private readonly ConcurrentDictionary<string, AssemblyCacheEntry> assemblyCache =
+            new ConcurrentDictionary<string, AssemblyCacheEntry>();
+
+        public void EnsureScanned()
+        {
+            if (globalCache == null)
+            {
+                globalCache = FolderExternalAnnotationsLoader.Create();
+            }
+        }
+
+        public bool HasAnnotationForSymbol(ISymbol symbol, bool appliesToItem, Compilation compilation)
+        {
+            Guard.NotNull(symbol, nameof(symbol));
+            Guard.NotNull(compilation, nameof(compilation));
+
+            return HasAnnotationInGlobalCache(symbol, appliesToItem) ||
+                HasAnnotationInSideBySideFile(symbol, appliesToItem, compilation);
+        }
+
+        private bool HasAnnotationInGlobalCache([NotNull] ISymbol symbol, bool appliesToItem)
+        {
+            return globalCache != null && globalCache.Contains(symbol, appliesToItem);
+        }
+
+        private bool HasAnnotationInSideBySideFile([NotNull] ISymbol symbol, bool appliesToItem,
+            [NotNull] Compilation compilation)
+        {
+            string path = AssemblyExternalAnnotationsLoader.GetPathForExternalSymbolOrNull(symbol, compilation);
+            if (path != null)
+            {
+                AssemblyCacheEntry entry = assemblyCache.GetOrAdd(path, CreateAssemblyCacheEntry);
+                return entry.Map.Contains(symbol, appliesToItem);
+            }
+
+            return false;
+        }
+
+        [NotNull]
+        private AssemblyCacheEntry CreateAssemblyCacheEntry([NotNull] string path)
+        {
+            ExternalAnnotationsMap assemblyAnnotationsMap = AssemblyExternalAnnotationsLoader.ParseFile(path);
+            FileSystemWatcher fileWatcher = CreateAssemblyAnnotationsFileWatcher(path);
+
+            return new AssemblyCacheEntry(assemblyAnnotationsMap, fileWatcher);
+        }
+
+        [NotNull]
+        private FileSystemWatcher CreateAssemblyAnnotationsFileWatcher([NotNull] string path)
+        {
+            string directoryName = Path.GetDirectoryName(path);
+            string filter = Path.GetFileName(path);
+            var assemblyAnnotationsFileWatcher = new FileSystemWatcher(directoryName, filter);
+
+            assemblyAnnotationsFileWatcher.Changed += WatcherOnChanged;
+            assemblyAnnotationsFileWatcher.Created += WatcherOnChanged;
+            assemblyAnnotationsFileWatcher.Deleted += WatcherOnChanged;
+            assemblyAnnotationsFileWatcher.Renamed += (s, e) => WatcherOnChanged(s, OldValuesFrom(e));
+
+            assemblyAnnotationsFileWatcher.EnableRaisingEvents = true;
+            return assemblyAnnotationsFileWatcher;
+        }
+
+        private void WatcherOnChanged([NotNull] object sender, [NotNull] FileSystemEventArgs e)
+        {
+            AssemblyCacheEntry existing;
+            if (assemblyCache.TryRemove(e.FullPath, out existing))
+            {
+                existing.Watcher.EnableRaisingEvents = false;
+                existing.Watcher.Dispose();
+            }
+        }
+
+        [NotNull]
+        private static FileSystemEventArgs OldValuesFrom([NotNull] RenamedEventArgs e)
+        {
+            string directory = Path.GetDirectoryName(e.OldFullPath);
+            return new FileSystemEventArgs(e.ChangeType, directory, e.OldName);
+        }
+
+        private sealed class AssemblyCacheEntry
+        {
+            [NotNull]
+            public ExternalAnnotationsMap Map { get; }
+
+            [NotNull]
+            public FileSystemWatcher Watcher { get; }
+
+            public AssemblyCacheEntry([NotNull] ExternalAnnotationsMap map, [NotNull] FileSystemWatcher watcher)
+            {
+                Guard.NotNull(map, nameof(map));
+                Guard.NotNull(watcher, nameof(watcher));
+
+                Map = map;
+                Watcher = watcher;
+            }
+        }
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/FolderExternalAnnotationsLoader.cs
+++ b/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/FolderExternalAnnotationsLoader.cs
@@ -17,7 +17,7 @@ namespace CodeContractNullability.ExternalAnnotations
     /// derives from such a built-in type, we need to have those definitions available because Resharper reports nullability
     /// annotation as unneeded when a base type is already decorated.
     /// </remarks>
-    public static class DiskExternalAnnotationsLoader
+    public static class FolderExternalAnnotationsLoader
     {
         [NotNull]
         private static readonly string CachePath =
@@ -149,21 +149,26 @@ namespace CodeContractNullability.ExternalAnnotations
         {
             string localAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-            var pathsToTry = new[]
+            var foldersToScan = new[]
             {
                 Path.Combine(localAppDataFolder, ExternalAnnotationFolders.Resharper9ForVisualStudio2015),
-                Path.Combine(localAppDataFolder, ExternalAnnotationFolders.Resharper8)
+                Path.Combine(localAppDataFolder, ExternalAnnotationFolders.Resharper9ExtensionsForVisualStudio2015)
             };
 
-            foreach (string path in pathsToTry)
+            var fileSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string folder in foldersToScan)
             {
-                if (Directory.Exists(path))
+                if (Directory.Exists(folder))
                 {
-                    return Directory.EnumerateFiles(path, "*.xml", SearchOption.AllDirectories);
+                    foreach (string path in Directory.EnumerateFiles(folder, "*.xml", SearchOption.AllDirectories))
+                    {
+                        fileSet.Add(path);
+                    }
                 }
             }
 
-            return new string[0];
+            return fileSet;
         }
 
         private static void Compact([NotNull] ExternalAnnotationsMap externalAnnotations)
@@ -202,7 +207,8 @@ namespace CodeContractNullability.ExternalAnnotations
             public const string Resharper9ForVisualStudio2015 =
                 @"JetBrains\Installations\ReSharperPlatformVs14\ExternalAnnotations";
 
-            public const string Resharper8 = @"JetBrains\ReSharper\vAny\packages";
+            public const string Resharper9ExtensionsForVisualStudio2015 =
+                @"JetBrains\Installations\ReSharperPlatformVs14\Extensions";
         }
     }
 }

--- a/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/IExternalAnnotationsResolver.cs
+++ b/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/IExternalAnnotationsResolver.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+
+namespace CodeContractNullability.ExternalAnnotations
+{
+    /// <summary>
+    /// Determines whether an external nullability annotation exists for a symbol.
+    /// </summary>
+    public interface IExternalAnnotationsResolver
+    {
+        void EnsureScanned();
+
+        bool HasAnnotationForSymbol([NotNull] ISymbol symbol, bool appliesToItem, [NotNull] Compilation compilation);
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/SimpleExternalAnnotationsResolver.cs
+++ b/src/CodeContractNullability/CodeContractNullability/ExternalAnnotations/SimpleExternalAnnotationsResolver.cs
@@ -1,0 +1,34 @@
+using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.Utilities;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+
+namespace CodeContractNullability.ExternalAnnotations
+{
+    /// <summary>
+    /// Provides a simple wrapper for an existing <see cref="ExternalAnnotationsMap" />.
+    /// </summary>
+    public sealed class SimpleExternalAnnotationsResolver : IExternalAnnotationsResolver
+    {
+        [NotNull]
+        private readonly ExternalAnnotationsMap source;
+
+        public SimpleExternalAnnotationsResolver([NotNull] ExternalAnnotationsMap source)
+        {
+            Guard.NotNull(source, nameof(source));
+
+            this.source = source;
+        }
+
+        public void EnsureScanned()
+        {
+        }
+
+        public bool HasAnnotationForSymbol(ISymbol symbol, bool appliesToItem, Compilation compilation)
+        {
+            Guard.NotNull(symbol, nameof(symbol));
+
+            return source.Contains(symbol, appliesToItem);
+        }
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/FieldAnalyzer.cs
+++ b/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/FieldAnalyzer.cs
@@ -1,4 +1,4 @@
-using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.ExternalAnnotations;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -10,7 +10,7 @@ namespace CodeContractNullability.SymbolAnalysis
     /// </summary>
     public class FieldAnalyzer : BaseSymbolAnalyzer<IFieldSymbol>
     {
-        public FieldAnalyzer(SymbolAnalysisContext context, [NotNull] ExternalAnnotationsMap externalAnnotations,
+        public FieldAnalyzer(SymbolAnalysisContext context, [NotNull] IExternalAnnotationsResolver externalAnnotations,
             [NotNull] GeneratedCodeDocumentCache generatedCodeCache, bool appliesToItem)
             : base(context, externalAnnotations, generatedCodeCache, appliesToItem)
         {

--- a/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/MethodReturnValueAnalyzer.cs
+++ b/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/MethodReturnValueAnalyzer.cs
@@ -1,4 +1,4 @@
-using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.ExternalAnnotations;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -11,7 +11,7 @@ namespace CodeContractNullability.SymbolAnalysis
     public class MethodReturnValueAnalyzer : BaseSymbolAnalyzer<IMethodSymbol>
     {
         public MethodReturnValueAnalyzer(SymbolAnalysisContext context,
-            [NotNull] ExternalAnnotationsMap externalAnnotations,
+            [NotNull] IExternalAnnotationsResolver externalAnnotations,
             [NotNull] GeneratedCodeDocumentCache generatedCodeCache, bool appliesToItem)
             : base(context, externalAnnotations, generatedCodeCache, appliesToItem)
         {
@@ -37,8 +37,8 @@ namespace CodeContractNullability.SymbolAnalysis
             IMethodSymbol baseMember = Symbol.OverriddenMethod;
             while (baseMember != null)
             {
-                if (baseMember.HasNullabilityAnnotation(AppliesToItem) ||
-                    ExternalAnnotations.Contains(baseMember, AppliesToItem) || HasAnnotationInInterface(baseMember))
+                if (baseMember.HasNullabilityAnnotation(AppliesToItem) || HasExternalAnnotationFor(baseMember) ||
+                    HasAnnotationInInterface(baseMember))
                 {
                     return true;
                 }

--- a/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/ParameterAnalyzer.cs
+++ b/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/ParameterAnalyzer.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Immutable;
-using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.ExternalAnnotations;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,7 +12,8 @@ namespace CodeContractNullability.SymbolAnalysis
     /// </summary>
     public class ParameterAnalyzer : BaseSymbolAnalyzer<IParameterSymbol>
     {
-        public ParameterAnalyzer(SymbolAnalysisContext context, [NotNull] ExternalAnnotationsMap externalAnnotations,
+        public ParameterAnalyzer(SymbolAnalysisContext context,
+            [NotNull] IExternalAnnotationsResolver externalAnnotations,
             [NotNull] GeneratedCodeDocumentCache generatedCodeCache, bool appliesToItem)
             : base(context, externalAnnotations, generatedCodeCache, appliesToItem)
         {
@@ -44,8 +45,7 @@ namespace CodeContractNullability.SymbolAnalysis
             IParameterSymbol baseParameter = TryGetBaseParameterFor(Symbol);
             while (baseParameter != null)
             {
-                if (baseParameter.HasNullabilityAnnotation(AppliesToItem) ||
-                    ExternalAnnotations.Contains(baseParameter, AppliesToItem) ||
+                if (baseParameter.HasNullabilityAnnotation(AppliesToItem) || HasExternalAnnotationFor(baseParameter) ||
                     HasAnnotationInInterface(baseParameter))
                 {
                     return true;
@@ -98,7 +98,7 @@ namespace CodeContractNullability.SymbolAnalysis
                         IParameterSymbol ifaceParameter = ifaceParameters[parameterIndex];
 
                         if (ifaceParameter.HasNullabilityAnnotation(AppliesToItem) ||
-                            ExternalAnnotations.Contains(ifaceParameter, AppliesToItem))
+                            HasExternalAnnotationFor(ifaceParameter))
                         {
                             return true;
                         }

--- a/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/PropertyAnalyzer.cs
+++ b/src/CodeContractNullability/CodeContractNullability/SymbolAnalysis/PropertyAnalyzer.cs
@@ -1,4 +1,4 @@
-using CodeContractNullability.ExternalAnnotations.Storage;
+using CodeContractNullability.ExternalAnnotations;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -10,7 +10,8 @@ namespace CodeContractNullability.SymbolAnalysis
     /// </summary>
     public class PropertyAnalyzer : BaseSymbolAnalyzer<IPropertySymbol>
     {
-        public PropertyAnalyzer(SymbolAnalysisContext context, [NotNull] ExternalAnnotationsMap externalAnnotations,
+        public PropertyAnalyzer(SymbolAnalysisContext context,
+            [NotNull] IExternalAnnotationsResolver externalAnnotations,
             [NotNull] GeneratedCodeDocumentCache generatedCodeCache, bool appliesToItem)
             : base(context, externalAnnotations, generatedCodeCache, appliesToItem)
         {
@@ -26,8 +27,8 @@ namespace CodeContractNullability.SymbolAnalysis
             IPropertySymbol baseMember = Symbol.OverriddenProperty;
             while (baseMember != null)
             {
-                if (baseMember.HasNullabilityAnnotation(AppliesToItem) ||
-                    ExternalAnnotations.Contains(baseMember, AppliesToItem) || HasAnnotationInInterface(baseMember))
+                if (baseMember.HasNullabilityAnnotation(AppliesToItem) || HasExternalAnnotationFor(baseMember) ||
+                    HasAnnotationInInterface(baseMember))
                 {
                     return true;
                 }


### PR DESCRIPTION
* Added parsing of external annotation files that live next to referenced assemblies ([AssemblyName].ExternalAnnotations.xml), such as in NuGet packages
* Added support for external annotation files that are shipped as Resharper extensions, such as https://github.com/robv8r/resharper-annotations.