### PR TITLE
Replaced FixAll provider with tweaked version from StyleCopAnalyzers

### DIFF
--- a/src/CodeContractNullability/CodeContractNullability/DocumentBasedFixAllProvider.cs
+++ b/src/CodeContractNullability/CodeContractNullability/DocumentBasedFixAllProvider.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace CodeContractNullability
+{
+    /// <summary>
+    /// Provides a base class to write a <see cref="FixAllProvider" /> that fixes documents independently.
+    /// <remarks>
+    /// Based on sources from project https://github.com/DotNetAnalyzers/StyleCopAnalyzers.
+    /// </remarks>
+    /// </summary>
+    internal abstract class DocumentBasedFixAllProvider : FixAllProvider
+    {
+        [NotNull]
+        [ItemNotNull]
+        public override Task<CodeAction> GetFixAsync([NotNull] FixAllContext fixAllContext)
+        {
+            CodeAction fixAction = null;
+
+            string codeActionTitle = GetCodeActionTitle(fixAllContext.CodeActionEquivalenceKey);
+
+            switch (fixAllContext.Scope)
+            {
+                case FixAllScope.Document:
+                {
+                    fixAction = CodeAction.Create(codeActionTitle,
+                        cancellationToken => GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                        nameof(DocumentBasedFixAllProvider));
+                    break;
+                }
+                case FixAllScope.Project:
+                {
+                    fixAction = CodeAction.Create(codeActionTitle,
+                        cancellationToken => GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken),
+                            fixAllContext.Project), nameof(DocumentBasedFixAllProvider));
+                    break;
+                }
+                case FixAllScope.Solution:
+                {
+                    fixAction = CodeAction.Create(codeActionTitle,
+                        cancellationToken => GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                        nameof(DocumentBasedFixAllProvider));
+                    break;
+                }
+            }
+
+            return Task.FromResult(fixAction);
+        }
+
+        [NotNull]
+        protected abstract string GetCodeActionTitle([NotNull] string codeActionEquivalenceKey);
+
+        /// <summary>
+        /// Fixes all occurrences of a diagnostic in a specific document.
+        /// </summary>
+        /// <param name="fixAllContext">
+        /// The context for the Fix All operation.
+        /// </param>
+        /// <param name="document">
+        /// The document to fix.
+        /// </param>
+        /// <param name="diagnostics">
+        /// The diagnostics to fix in the document.
+        /// </param>
+        /// <returns>
+        /// <para>
+        /// The new <see cref="SyntaxNode" /> representing the root of the fixed document.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <see langword="null" />, if no changes were made to the document.
+        /// </para>
+        /// </returns>
+        [NotNull]
+        [ItemCanBeNull]
+        protected abstract Task<SyntaxNode> FixAllInDocumentAsync([NotNull] FixAllContext fixAllContext,
+            [NotNull] Document document, [ItemNotNull] ImmutableArray<Diagnostic> diagnostics);
+
+        [ItemNotNull]
+        private async Task<Document> GetDocumentFixesAsync([NotNull] FixAllContext fixAllContext)
+        {
+            ImmutableDictionary<Document, ImmutableArray<Diagnostic>> documentDiagnosticsToFix =
+                await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+
+            if (!documentDiagnosticsToFix.TryGetValue(fixAllContext.Document, out ImmutableArray<Diagnostic> diagnostics))
+            {
+                return fixAllContext.Document;
+            }
+
+            SyntaxNode newRoot = await FixAllInDocumentAsync(fixAllContext, fixAllContext.Document, diagnostics)
+                .ConfigureAwait(false);
+
+            return newRoot == null ? fixAllContext.Document : fixAllContext.Document.WithSyntaxRoot(newRoot);
+        }
+
+        [ItemNotNull]
+        private async Task<Solution> GetSolutionFixesAsync([NotNull] FixAllContext fixAllContext,
+            [ItemNotNull] ImmutableArray<Document> documents)
+        {
+            ImmutableDictionary<Document, ImmutableArray<Diagnostic>> documentDiagnosticsToFix =
+                await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+
+            Solution solution = fixAllContext.Solution;
+            var newDocuments = new List<Task<SyntaxNode>>(documents.Length);
+
+            foreach (Document document in documents)
+            {
+                if (!documentDiagnosticsToFix.TryGetValue(document, out ImmutableArray<Diagnostic> diagnostics))
+                {
+                    newDocuments.Add(document.GetSyntaxRootAsync(fixAllContext.CancellationToken));
+                    continue;
+                }
+
+                newDocuments.Add(FixAllInDocumentAsync(fixAllContext, document, diagnostics));
+            }
+
+            for (int i = 0; i < documents.Length; i++)
+            {
+                SyntaxNode newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
+                if (newDocumentRoot == null)
+                {
+                    continue;
+                }
+
+                solution = solution.WithDocumentSyntaxRoot(documents[i].Id, newDocumentRoot);
+            }
+
+            return solution;
+        }
+
+        [NotNull]
+        [ItemNotNull]
+        private Task<Solution> GetProjectFixesAsync([NotNull] FixAllContext fixAllContext, [NotNull] Project project)
+        {
+            return GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+        }
+
+        [NotNull]
+        [ItemNotNull]
+        private Task<Solution> GetSolutionFixesAsync([NotNull] FixAllContext fixAllContext)
+        {
+            ImmutableArray<Document> documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
+            return GetSolutionFixesAsync(fixAllContext, documents);
+        }
+    }
+}

--- a/src/CodeContractNullability/CodeContractNullability/FixAllContextHelper.cs
+++ b/src/CodeContractNullability/CodeContractNullability/FixAllContextHelper.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace CodeContractNullability
+{
+    /// <remarks>
+    /// Based on sources from project https://github.com/DotNetAnalyzers/StyleCopAnalyzers.
+    /// </remarks>
+    internal static class FixAllContextHelper
+    {
+        [ItemNotNull]
+        public static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
+            [NotNull] FixAllContext fixAllContext)
+        {
+            ImmutableArray<Diagnostic> allDiagnostics = ImmutableArray<Diagnostic>.Empty;
+            ImmutableArray<Project> projectsToFix = ImmutableArray<Project>.Empty;
+
+            Document document = fixAllContext.Document;
+            Project project = fixAllContext.Project;
+
+            switch (fixAllContext.Scope)
+            {
+                case FixAllScope.Document:
+                {
+                    if (document != null)
+                    {
+                        ImmutableArray<Diagnostic> documentDiagnostics =
+                            await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+
+                        return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty.SetItem(document,
+                            documentDiagnostics);
+                    }
+
+                    break;
+                }
+                case FixAllScope.Project:
+                {
+                    projectsToFix = ImmutableArray.Create(project);
+                    allDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, project).ConfigureAwait(false);
+
+                    break;
+                }
+                case FixAllScope.Solution:
+                {
+                    projectsToFix = project.Solution.Projects.Where(p => p.Language == project.Language).ToImmutableArray();
+
+                    var diagnostics = new ConcurrentDictionary<ProjectId, ImmutableArray<Diagnostic>>();
+                    var tasks = new Task[projectsToFix.Length];
+
+                    for (int i = 0; i < projectsToFix.Length; i++)
+                    {
+                        fixAllContext.CancellationToken.ThrowIfCancellationRequested();
+
+                        Project projectToFix = projectsToFix[i];
+                        tasks[i] = Task.Run(async () =>
+                        {
+                            ImmutableArray<Diagnostic> projectDiagnostics =
+                                await GetAllDiagnosticsAsync(fixAllContext, projectToFix).ConfigureAwait(false);
+
+                            diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
+                        }, fixAllContext.CancellationToken);
+                    }
+
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                    allDiagnostics = allDiagnostics.AddRange(diagnostics.SelectMany(i =>
+                        i.Value.Where(x => fixAllContext.DiagnosticIds.Contains(x.Id))));
+                    break;
+                }
+            }
+
+            if (allDiagnostics.IsEmpty)
+            {
+                return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty;
+            }
+
+            return await GetDocumentDiagnosticsToFixAsync(allDiagnostics, projectsToFix, fixAllContext.CancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Diagnostic" /> instances within a specific <see cref="Project" /> which are relevant to a
+        /// <see cref="FixAllContext" />.
+        /// </summary>
+        /// <param name="fixAllContext">
+        /// The context for the Fix All operation.
+        /// </param>
+        /// <param name="project">
+        /// The project.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> representing the asynchronous operation. When the task completes successfully, the
+        /// <see cref="Task{TResult}.Result" /> will contain the requested diagnostics.
+        /// </returns>
+        private static async Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync([NotNull] FixAllContext fixAllContext,
+            [NotNull] Project project)
+        {
+            return await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+        }
+
+        [ItemNotNull]
+        private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
+            [ItemNotNull] ImmutableArray<Diagnostic> diagnostics, [ItemNotNull] ImmutableArray<Project> projects,
+            CancellationToken cancellationToken)
+        {
+            ImmutableDictionary<SyntaxTree, Document> treeToDocumentMap =
+                await GetTreeToDocumentMapAsync(projects, cancellationToken).ConfigureAwait(false);
+
+            ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Builder builder =
+                ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
+
+            foreach (IGrouping<Document, Diagnostic> documentAndDiagnostics in diagnostics.GroupBy(d =>
+                GetReportedDocument(d, treeToDocumentMap)))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Document document = documentAndDiagnostics.Key;
+                ImmutableArray<Diagnostic> diagnosticsForDocument = documentAndDiagnostics.ToImmutableArray();
+
+                builder.Add(document, diagnosticsForDocument);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        [ItemNotNull]
+        private static async Task<ImmutableDictionary<SyntaxTree, Document>> GetTreeToDocumentMapAsync(
+            [ItemNotNull] ImmutableArray<Project> projects, CancellationToken cancellationToken)
+        {
+            ImmutableDictionary<SyntaxTree, Document>.Builder builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Document>();
+            foreach (Project project in projects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (Document document in project.Documents)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    SyntaxTree tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                    builder.Add(tree, document);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        [CanBeNull]
+        private static Document GetReportedDocument([NotNull] Diagnostic diagnostic,
+            [NotNull] ImmutableDictionary<SyntaxTree, Document> treeToDocumentsMap)
+        {
+            SyntaxTree tree = diagnostic.Location.SourceTree;
+            return tree != null && treeToDocumentsMap.TryGetValue(tree, out Document document) ? document : null;
+        }
+    }
+}


### PR DESCRIPTION
This makes the fixer 5x faster, no longer use excessive memory and cause a lot less merge conflicts, resulting in more changes.

Fixes #36.